### PR TITLE
CI: inherit secrets in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,6 +14,7 @@ jobs:
     coverage:
         name: "Nette Tester"
         uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
+        secrets: inherit
         with:
             php: "8.4"
             make: "init coverage"


### PR DESCRIPTION
## What changed

- Added `secrets: inherit` to the coverage workflow caller so the reusable coverage workflow receives required secrets.

## Why

- This completes the issue 74 rollout for this repository and keeps coverage CI compatible with the shared workflow requirements.
- Related: contributte/contributte#74